### PR TITLE
Allow TARGET and DEPLOY_RUNTIME  to be set without modifying Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ MODULE_DIRS = $(foreach mod,$(MODULES),modules/$(mod))
 #
 # Default deplyment target. May be overridden to deploy to an alternative location.
 #
-TARGET = /kb/deployment
-DEPLOY_RUNTIME = /kb/runtime
+TARGET ?= /kb/deployment
+DEPLOY_RUNTIME ?= /kb/runtime
 
 all: build_modules
 


### PR DESCRIPTION
When I do the deployments it would be handy if I didn't have to modify the Makefile.
