### PR TITLE
determine runtime properly

### DIFF
--- a/tools/Makefile.common
+++ b/tools/Makefile.common
@@ -2,6 +2,10 @@ ifeq ($(KB_TOP),)
      $(error The KB_TOP environment is not set - have you sourced your user-env.sh file?)
 endif
 
+RUNTIME_BIN = $(shell if [[ -x $(KB_RUNTIME)/bin/perl ]] ; then echo $(KB_RUNTIME)/bin ; else echo $(DEPLOY_RUNTIME)/bin ; fi )
+PERL = $(RUNTIME_BIN)/perl
+TPAGE = $(RUNTIME_BIN)/tpage
+
 SERVICE_USER = kbase
 
 BIN_DIR = $(TOP_DIR)/bin
@@ -46,7 +50,7 @@ SERVICE_DIR = $(TARGET)/services/$(SERVICE)
 
 SERVICE_SUBDIRS = webroot
 
-TPAGE = $(DEPLOY_RUNTIME)/bin/perl $(DEPLOY_RUNTIME)/bin/tpage
+#TPAGE = $(DEPLOY_RUNTIME)/bin/perl $(DEPLOY_RUNTIME)/bin/tpage
 MK_CONFIG = $(TOOLS_DIR)/mkcfg
 
 JAVA = java


### PR DESCRIPTION
In cases where the runtime is not installed in /kb/runtime builds that
use $(TPAGE) fail because of its dependency on the proper value of
DEPLOY_RUNTIME. This patch sets up a $(RUNTIME_BIN) that is computed
based first on the value of KB_RUNTIME and falling back to
DEPLOY_RUNTIME. It sets TPAGE accordingly.

I think this is safe; however for some reason the older definition of
TPAGE explicitly invoked perl on the tpage executable. I suspect this
may have been because of some improper installations of tpage (from the
perl Template::Toolkit library) but I am not sure.

Someone other than me should probably also test against this.
