### PR TITLE
Create shbin directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ deploy-dirs:
 	-mkdir $(TARGET)/plbin
 	-mkdir $(TARGET)/pybin
 	-mkdir $(TARGET)/rsbin
+	-mkdir $(TARGET)/shbin
 	-mkdir $(TARGET)/services
 
 # make the necessary deployment directories


### PR DESCRIPTION
Due to wrap_sh.sh, it expect $(TARGET)/shbin directory to be exist, which caused RNA seq. service deployment error.
